### PR TITLE
if dates are blank null or 0 they should clear the value instead of b…

### DIFF
--- a/fields/types/datetime/DatetimeType.js
+++ b/fields/types/datetime/DatetimeType.js
@@ -52,6 +52,10 @@ datetime.prototype.getInputFromData = function (data) {
 			combined += ' ' + tzOffsetValue;
 		}
 		return combined;
+	} else if (dateValue !== undefined && timeValue !== undefined) {
+		// when it comes here the dateValue and timeValue are invalid but not undefined
+		// like null, '' or 0
+		return '';
 	}
 
 	return this.getValueFromData(data);


### PR DESCRIPTION
It didn't make a distinction between undefined and '', 0 or null